### PR TITLE
Feature/grid_box

### DIFF
--- a/frontend/components/GridBox.tsx
+++ b/frontend/components/GridBox.tsx
@@ -14,6 +14,6 @@ const Box = styled.div`
   width: 100%;
   display: grid;
   grid-auto-flow: row;
-  grid-gap: 12px;
+  grid-gap: 16px;
   grid-template-columns: 3fr 9fr;
 `;

--- a/frontend/components/GridBox.tsx
+++ b/frontend/components/GridBox.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+import styled from 'styled-components';
+type Props = {
+  children: ReactNode;
+};
+
+const GridBox = (props: Props) => {
+  return <Box {...props} />;
+};
+
+export default GridBox;
+
+const Box = styled.div`
+  width: 100%;
+  display: grid;
+  grid-auto-flow: row;
+  grid-gap: 12px;
+  grid-template-columns: 3fr 9fr;
+`;


### PR DESCRIPTION
- 전체 Props를 전달받아 자유롭게 활용할 수 있는 컴포넌트입니다.

- 페이지를 구성할 때, Grid 3칸과 9칸으로 나눠져있는 페이지에서 활용하시면 됩니다.


예시  
```js
<Box>
<div>왼쪽 3칸</div>
<div>오른쪽 9칸</div>
</Box>
```

![localhost 3000 project create](https://user-images.githubusercontent.com/117655658/235708662-fb7a7f71-c2a0-418a-88a6-101c1d656004.png)