### PR TITLE
style : margin-right 삭제

### DIFF
--- a/frontend/components/Tag.tsx
+++ b/frontend/components/Tag.tsx
@@ -16,5 +16,4 @@ const TagBox = styled.div`
   border-radius: var(--radius-sm);
   min-width: 48px;
   text-align: center;
-  margin-right: 8px;
 `;


### PR DESCRIPTION
- margin-right 속성을 삭제하였습니다. 태그 컴포넌트의 부모요소에서 gap 속성을 사용해주시면 됩니다.